### PR TITLE
Localize core UI strings in Chinese

### DIFF
--- a/applications/main/nfc/nfc_app_i.h
+++ b/applications/main/nfc/nfc_app_i.h
@@ -91,7 +91,11 @@
 
 #define NFC_MFKEY32_APP_PATH (EXT_PATH("apps/NFC/mfkey.fap"))
 
+#ifdef MOMENTUM_UI_LANG_ZH_CN
+#define NFC_UI_TEXT(en, zh) (zh)
+#else
 #define NFC_UI_TEXT(en, zh) (en)
+#endif
 
 typedef enum {
     NfcRpcStateIdle,

--- a/applications/services/bt/bt_service/bt.c
+++ b/applications/services/bt/bt_service/bt.c
@@ -17,6 +17,12 @@
 
 #define ICON_SPACER 2
 
+#ifdef MOMENTUM_UI_LANG_ZH_CN
+#define BT_UI_TEXT(en, zh) (zh)
+#else
+#define BT_UI_TEXT(en, zh) (en)
+#endif
+
 static void bt_draw_statusbar_callback(Canvas* canvas, void* context) {
     furi_assert(context);
 
@@ -46,9 +52,13 @@ static void bt_pin_code_view_port_draw_callback(Canvas* canvas, void* context) {
     Bt* bt = context;
     char pin_code_info[24];
     canvas_draw_icon(canvas, 0, 0, &I_BLE_Pairing_128x64);
-    snprintf(pin_code_info, sizeof(pin_code_info), "Pairing code\n%06lu", bt->pin_code);
+    snprintf(
+        pin_code_info,
+        sizeof(pin_code_info),
+        BT_UI_TEXT("Pairing code\n%06lu", "配对码\n%06lu"),
+        bt->pin_code);
     elements_multiline_text_aligned(canvas, 64, 4, AlignCenter, AlignTop, pin_code_info);
-    elements_button_left(canvas, "Quit");
+    elements_button_left(canvas, BT_UI_TEXT("Quit", "退出"));
 }
 
 static void bt_pin_code_view_port_input_callback(InputEvent* event, void* context) {

--- a/applications/services/gui/modules/byte_input.c
+++ b/applications/services/gui/modules/byte_input.c
@@ -4,6 +4,12 @@
 #include <furi.h>
 #include <assets_icons.h>
 
+#ifdef MOMENTUM_UI_LANG_ZH_CN
+#define BYTE_INPUT_UI_TEXT(en, zh) (zh)
+#else
+#define BYTE_INPUT_UI_TEXT(en, zh) (en)
+#endif
+
 /** ByteInput type */
 struct ByteInput {
     View* view;
@@ -600,13 +606,23 @@ static void byte_input_view_draw_callback(Canvas* canvas, void* _model) {
     if(model->selected_row == -2) {
         canvas_set_font(canvas, FontSecondary);
         canvas_draw_icon(canvas, 3, 1, &I_Pin_back_arrow_10x8);
-        canvas_draw_str_aligned(canvas, 16, 9, AlignLeft, AlignBottom, "back to keyboard");
-        elements_button_center(canvas, "Save");
+        canvas_draw_str_aligned(
+            canvas,
+            16,
+            9,
+            AlignLeft,
+            AlignBottom,
+            BYTE_INPUT_UI_TEXT("back to keyboard", "返回键盘"));
+        elements_button_center(canvas, BYTE_INPUT_UI_TEXT("Save", "保存"));
     } else {
         // Draw the header
         canvas_set_font(canvas, FontSecondary);
         if(model->selected_row == -1) {
-            canvas_draw_str(canvas, 10, 9, "Move up for alternate input");
+            canvas_draw_str(
+                canvas,
+                10,
+                9,
+                BYTE_INPUT_UI_TEXT("Move up for alternate input", "上移切换输入"));
             canvas_draw_icon(canvas, 3, 4, &I_SmallArrowUp_3x5);
         } else {
             canvas_draw_str(canvas, 2, 9, model->header);

--- a/applications/services/gui/modules/menu.c
+++ b/applications/services/gui/modules/menu.c
@@ -14,6 +14,12 @@
 #include <momentum/momentum.h>
 #include <m-string.h>
 
+#ifdef MOMENTUM_UI_LANG_ZH_CN
+#define MENU_UI_TEXT(en, zh) (zh)
+#else
+#define MENU_UI_TEXT(en, zh) (en)
+#endif
+
 struct Menu {
     View* view;
 
@@ -232,7 +238,11 @@ static void menu_draw_callback(Canvas* canvas, void* _model) {
                 canvas, 1, 1, AlignLeft, AlignTop, furi_hal_version_get_name_ptr());
             char str[10];
             Dolphin* dolphin = furi_record_open(RECORD_DOLPHIN);
-            snprintf(str, 10, "Level %i", dolphin_get_level(dolphin->state->data.icounter));
+            snprintf(
+                str,
+                10,
+                MENU_UI_TEXT("Level %i", "%i 级"),
+                dolphin_get_level(dolphin->state->data.icounter));
             furi_record_close(RECORD_DOLPHIN);
             canvas_draw_str_aligned(canvas, 127, 1, AlignRight, AlignTop, str);
             for(int8_t i = -1; i <= 4; i++) {
@@ -251,7 +261,12 @@ static void menu_draw_callback(Canvas* canvas, void* _model) {
                     canvas_set_color(canvas, ColorWhite);
                     canvas_set_font(canvas, FontBatteryPercent);
                     canvas_draw_str_aligned(
-                        canvas, pos_x, pos_y + height / 2 + 1, AlignCenter, AlignTop, "Start");
+                        canvas,
+                        pos_x,
+                        pos_y + height / 2 + 1,
+                        AlignCenter,
+                        AlignTop,
+                        MENU_UI_TEXT("Start", "启动"));
 
                     canvas_set_color(canvas, ColorBlack);
                     canvas_set_font(canvas, FontSecondary);
@@ -436,7 +451,11 @@ static void menu_draw_callback(Canvas* canvas, void* _model) {
 
             // Display OTG state
             char ext5v_display[20];
-            snprintf(ext5v_display, sizeof(ext5v_display), "5v: %s", ext5v ? "On" : "Off");
+            snprintf(
+                ext5v_display,
+                sizeof(ext5v_display),
+                MENU_UI_TEXT("5v: %s", "5V: %s"),
+                ext5v ? MENU_UI_TEXT("On", "开") : MENU_UI_TEXT("Off", "关"));
             canvas_draw_str(canvas, 5, 56, ext5v_display);
 
             MenuItem* item = MenuItemArray_get(model->items, position);
@@ -575,7 +594,7 @@ static void menu_draw_callback(Canvas* canvas, void* _model) {
 
         furi_string_free(name);
     } else {
-        canvas_draw_str(canvas, 2, 32, "Empty");
+        canvas_draw_str(canvas, 2, 32, MENU_UI_TEXT("Empty", "空"));
         elements_scrollbar(canvas, 0, 0);
     }
 }

--- a/applications/services/loader/loader.c
+++ b/applications/services/loader/loader.c
@@ -16,6 +16,12 @@
 
 #define LOADER_MAGIC_THREAD_VALUE 0xDEADBEEF
 
+#ifdef MOMENTUM_UI_LANG_ZH_CN
+#define LOADER_UI_TEXT(en, zh) (zh)
+#else
+#define LOADER_UI_TEXT(en, zh) (en)
+#endif
+
 // helpers
 
 static const char* loader_find_external_application_by_name(const char* app_name) {
@@ -144,22 +150,30 @@ static void loader_show_gui_error(
             break;
         case LoaderStatusErrorOutOfMemory:
             dialog_message_set_header(
-                message, "Error: Out of Memory", 64, 0, AlignCenter, AlignTop);
+                message,
+                LOADER_UI_TEXT("Error: Out of Memory", "错误: 内存不足"),
+                64,
+                0,
+                AlignCenter,
+                AlignTop);
             dialog_message_set_text(
                 message,
-                "Not enough RAM to run the\napp. Please reboot the device",
+                LOADER_UI_TEXT(
+                    "Not enough RAM to run the\napp. Please reboot the device",
+                    "运行应用的 RAM 不足。\n请重启设备。"),
                 64,
                 13,
                 AlignCenter,
                 AlignTop);
-            dialog_message_set_buttons(message, NULL, NULL, "Reboot");
+            dialog_message_set_buttons(message, NULL, NULL, LOADER_UI_TEXT("Reboot", "重启"));
             if(dialog_message_show(dialogs, message) == DialogMessageButtonRight) {
                 furi_hal_power_reset();
             }
             break;
         default:
             // Generic error
-            dialog_message_set_header(message, "Error", 64, 0, AlignCenter, AlignTop);
+            dialog_message_set_header(
+                message, LOADER_UI_TEXT("Error", "错误"), 64, 0, AlignCenter, AlignTop);
 
             furi_string_replace(error_message, "/ext/apps/", "");
             furi_string_replace(error_message, ", ", "\n");

--- a/applications/services/loader/loader_menu_storage.c
+++ b/applications/services/loader/loader_menu_storage.c
@@ -14,6 +14,12 @@ typedef enum {
     FormatFlagAll = (FormatFlagContinue | FormatFlagCancel),
 } FormatFlag;
 
+#ifdef MOMENTUM_UI_LANG_ZH_CN
+#define LOADER_STORAGE_UI_TEXT(en, zh) (zh)
+#else
+#define LOADER_STORAGE_UI_TEXT(en, zh) (en)
+#endif
+
 static void loader_menu_storage_settings_callback(DialogExResult result, void* context) {
     FuriThread* thread = context;
     furi_thread_flags_set(
@@ -47,36 +53,65 @@ int32_t loader_menu_storage_settings(void* context) {
         view_holder_set_back_callback(
             view_holder, loader_menu_storage_settings_back, furi_thread_get_current());
 
-        dialog_ex_set_header(dialog_ex, "Update needed", 64, 0, AlignCenter, AlignTop);
+        dialog_ex_set_header(
+            dialog_ex,
+            LOADER_STORAGE_UI_TEXT("Update needed", "需要更新"),
+            64,
+            0,
+            AlignCenter,
+            AlignTop);
         dialog_ex_set_text(
             dialog_ex,
-            "Reinstall firmware\n"
-            "to run this app.\n"
-            "Can format SD\n"
-            "here if needed.",
+            LOADER_STORAGE_UI_TEXT(
+                "Reinstall firmware\n"
+                "to run this app.\n"
+                "Can format SD\n"
+                "here if needed.",
+                "请重装固件\n"
+                "以运行此应用。\n"
+                "如有需要\n"
+                "可在此格式化 SD。"),
             3,
             17,
             AlignLeft,
             AlignTop);
         dialog_ex_set_icon(dialog_ex, 83, 11, &I_WarningDolphinFlip_45x42);
-        dialog_ex_set_right_button_text(dialog_ex, "Format SD");
+        dialog_ex_set_right_button_text(
+            dialog_ex, LOADER_STORAGE_UI_TEXT("Format SD", "格式化 SD"));
 
         FormatFlag flag = furi_thread_flags_wait(FormatFlagAll, FuriFlagWaitAny, FuriWaitForever);
         if(flag == FormatFlagContinue) {
-            char text[39];
-            dialog_ex_set_header(dialog_ex, "Format SD Card?", 64, 0, AlignCenter, AlignTop);
+            char text[96];
+            dialog_ex_set_header(
+                dialog_ex,
+                LOADER_STORAGE_UI_TEXT("Format SD Card?", "格式化 SD 卡?"),
+                64,
+                0,
+                AlignCenter,
+                AlignTop);
             dialog_ex_set_icon(dialog_ex, 0, 0, NULL);
-            dialog_ex_set_left_button_text(dialog_ex, "Cancel");
-            dialog_ex_set_right_button_text(dialog_ex, "Format");
+            dialog_ex_set_left_button_text(dialog_ex, LOADER_STORAGE_UI_TEXT("Cancel", "取消"));
+            dialog_ex_set_right_button_text(dialog_ex, LOADER_STORAGE_UI_TEXT("Format", "格式化"));
             for(uint8_t counter = 5; counter > 0; counter--) {
-                snprintf(text, sizeof(text), "All data will be lost!\n%d presses left", counter);
+                snprintf(
+                    text,
+                    sizeof(text),
+                    LOADER_STORAGE_UI_TEXT(
+                        "All data will be lost!\n%d presses left",
+                        "所有数据将丢失!\n还需按 %d 次"),
+                    counter);
                 dialog_ex_set_text(dialog_ex, text, 64, 12, AlignCenter, AlignTop);
                 flag = furi_thread_flags_wait(FormatFlagAll, FuriFlagWaitAny, FuriWaitForever);
                 if(flag != FormatFlagContinue) break;
 
                 if(counter == 1) {
                     dialog_ex_set_header(
-                        dialog_ex, "Formatting...", 70, 32, AlignCenter, AlignCenter);
+                        dialog_ex,
+                        LOADER_STORAGE_UI_TEXT("Formatting...", "格式化中..."),
+                        70,
+                        32,
+                        AlignCenter,
+                        AlignCenter);
                     dialog_ex_set_text(dialog_ex, NULL, 0, 0, AlignCenter, AlignCenter);
                     dialog_ex_set_icon(dialog_ex, 15, 20, &I_LoadingHourglass_24x24);
                     dialog_ex_set_left_button_text(dialog_ex, NULL);
@@ -85,7 +120,12 @@ int32_t loader_menu_storage_settings(void* context) {
                     FS_Error error = storage_sd_format(storage);
                     if(error != FSE_OK) {
                         dialog_ex_set_header(
-                            dialog_ex, "Cannot Format SD Card", 64, 10, AlignCenter, AlignCenter);
+                            dialog_ex,
+                            LOADER_STORAGE_UI_TEXT("Cannot Format SD Card", "无法格式化 SD 卡"),
+                            64,
+                            10,
+                            AlignCenter,
+                            AlignCenter);
                         dialog_ex_set_icon(dialog_ex, 0, 0, NULL);
                         dialog_ex_set_text(
                             dialog_ex,
@@ -96,9 +136,16 @@ int32_t loader_menu_storage_settings(void* context) {
                             AlignCenter);
                     } else {
                         dialog_ex_set_icon(dialog_ex, 48, 6, &I_DolphinDone_80x58);
-                        dialog_ex_set_header(dialog_ex, "Formatted", 5, 10, AlignLeft, AlignTop);
+                        dialog_ex_set_header(
+                            dialog_ex,
+                            LOADER_STORAGE_UI_TEXT("Formatted", "已格式化"),
+                            5,
+                            10,
+                            AlignLeft,
+                            AlignTop);
                     }
-                    dialog_ex_set_left_button_text(dialog_ex, "Finish");
+                    dialog_ex_set_left_button_text(
+                        dialog_ex, LOADER_STORAGE_UI_TEXT("Finish", "完成"));
                     furi_thread_flags_wait(FormatFlagAll, FuriFlagWaitAny, FuriWaitForever);
                 }
             }

--- a/applications/services/power/power_service/views/power_off.c
+++ b/applications/services/power/power_service/views/power_off.c
@@ -3,6 +3,12 @@
 #include <gui/elements.h>
 #include <assets_icons.h>
 
+#ifdef MOMENTUM_UI_LANG_ZH_CN
+#define POWER_OFF_UI_TEXT(en, zh) (zh)
+#else
+#define POWER_OFF_UI_TEXT(en, zh) (en)
+#endif
+
 struct PowerOff {
     View* view;
 };
@@ -15,28 +21,34 @@ typedef struct {
 static void power_off_draw_callback(Canvas* canvas, void* _model) {
     furi_assert(_model);
     PowerOffModel* model = _model;
-    char buff[32];
+    char buff[64];
 
     canvas_set_color(canvas, ColorBlack);
     canvas_set_font(canvas, FontPrimary);
-    canvas_draw_str_aligned(canvas, 64, 1, AlignCenter, AlignTop, "Battery low!");
+    canvas_draw_str_aligned(
+        canvas, 64, 1, AlignCenter, AlignTop, POWER_OFF_UI_TEXT("Battery low!", "电量低!"));
     canvas_draw_icon(canvas, 0, 18, &I_BatteryBody_52x28);
     canvas_draw_icon(canvas, 16, 25, &I_FaceNopower_29x14);
     elements_bubble(canvas, 54, 17, 70, 30);
 
     canvas_set_font(canvas, FontSecondary);
     if(model->response == PowerOffResponseDefault) {
-        snprintf(buff, sizeof(buff), "Charge me!\nOff in %lus!", model->time_left_sec);
+        snprintf(
+            buff,
+            sizeof(buff),
+            POWER_OFF_UI_TEXT("Charge me!\nOff in %lus!", "请充电!\n%lu 秒后关机!"),
+            model->time_left_sec);
         elements_multiline_text_aligned(canvas, 70, 23, AlignLeft, AlignTop, buff);
 
-        elements_button_left(canvas, "Cancel");
-        elements_button_center(canvas, "OK");
-        elements_button_right(canvas, "Hide");
+        elements_button_left(canvas, POWER_OFF_UI_TEXT("Cancel", "取消"));
+        elements_button_center(canvas, POWER_OFF_UI_TEXT("OK", "确定"));
+        elements_button_right(canvas, POWER_OFF_UI_TEXT("Hide", "隐藏"));
     } else {
-        snprintf(buff, sizeof(buff), "Charge me!\nDon't forget!");
+        snprintf(buff, sizeof(buff), POWER_OFF_UI_TEXT("Charge me!\nDon't forget!", "请充电!\n不要忘记!"));
         elements_multiline_text_aligned(canvas, 70, 23, AlignLeft, AlignTop, buff);
 
-        canvas_draw_str_aligned(canvas, 64, 60, AlignCenter, AlignBottom, "Hold a second...");
+        canvas_draw_str_aligned(
+            canvas, 64, 60, AlignCenter, AlignBottom, POWER_OFF_UI_TEXT("Hold a second...", "请稍候..."));
     }
 }
 

--- a/applications/settings/storage_settings/scenes/storage_settings_scene_benchmark.c
+++ b/applications/settings/storage_settings/scenes/storage_settings_scene_benchmark.c
@@ -77,7 +77,8 @@ static bool
 static void storage_settings_scene_benchmark(StorageSettings* app) {
     DialogEx* dialog_ex = app->dialog_ex;
     uint8_t* bench_data;
-    dialog_ex_set_header(dialog_ex, "Preparing Data...", 64, 32, AlignCenter, AlignCenter);
+    dialog_ex_set_header(
+        dialog_ex, STORAGE_SETTINGS_UI_TEXT("Preparing Data...", "准备数据中..."), 64, 32, AlignCenter, AlignCenter);
 
     bench_data = malloc(BENCH_DATA_SIZE);
     for(size_t i = 0; i < BENCH_DATA_SIZE; i++) {
@@ -88,7 +89,8 @@ static void storage_settings_scene_benchmark(StorageSettings* app) {
     uint32_t bench_w_speed[BENCH_COUNT] = {0, 0, 0, 0, 0, 0};
     uint32_t bench_r_speed[BENCH_COUNT] = {0, 0, 0, 0, 0, 0};
 
-    dialog_ex_set_header(dialog_ex, "Benchmarking...", 74, 32, AlignCenter, AlignCenter);
+    dialog_ex_set_header(
+        dialog_ex, STORAGE_SETTINGS_UI_TEXT("Benchmarking...", "测速中..."), 74, 32, AlignCenter, AlignCenter);
     dialog_ex_set_icon(dialog_ex, 12, 20, &I_LoadingHourglass_24x24);
     for(size_t i = 0; i < BENCH_COUNT; i++) {
         if(!storage_settings_scene_bench_write(
@@ -136,10 +138,22 @@ void storage_settings_scene_benchmark_on_enter(void* context) {
 
     if(sd_status != FSE_OK) {
         dialog_ex_set_icon(dialog_ex, 83, 22, &I_WarningDolphinFlip_45x42);
-        dialog_ex_set_header(dialog_ex, "SD Card Not Mounted", 64, 3, AlignCenter, AlignTop);
+        dialog_ex_set_header(
+            dialog_ex,
+            STORAGE_SETTINGS_UI_TEXT("SD Card Not Mounted", "SD 卡未挂载"),
+            64,
+            3,
+            AlignCenter,
+            AlignTop);
         dialog_ex_set_text(
-            dialog_ex, "Try to reinsert\nor format SD\ncard.", 3, 19, AlignLeft, AlignTop);
-        dialog_ex_set_center_button_text(dialog_ex, "Ok");
+            dialog_ex,
+            STORAGE_SETTINGS_UI_TEXT(
+                "Try to reinsert\nor format SD\ncard.", "请重新插入\n或格式化\nSD 卡。"),
+            3,
+            19,
+            AlignLeft,
+            AlignTop);
+        dialog_ex_set_center_button_text(dialog_ex, STORAGE_SETTINGS_UI_TEXT("Ok", "确定"));
     } else {
         storage_settings_scene_benchmark(app);
         notification_message(app->notification, &sequence_blink_green_100);

--- a/applications/settings/storage_settings/scenes/storage_settings_scene_formatting.c
+++ b/applications/settings/storage_settings/scenes/storage_settings_scene_formatting.c
@@ -34,7 +34,8 @@ void storage_settings_scene_formatting_on_enter(void* context) {
     FS_Error error;
     DialogEx* dialog_ex = app->dialog_ex;
 
-    dialog_ex_set_header(dialog_ex, "Formatting...", 70, 32, AlignCenter, AlignCenter);
+    dialog_ex_set_header(
+        dialog_ex, STORAGE_SETTINGS_UI_TEXT("Formatting...", "格式化中..."), 70, 32, AlignCenter, AlignCenter);
     dialog_ex_set_icon(dialog_ex, 15, 20, &I_LoadingHourglass_24x24);
     view_dispatcher_switch_to_view(app->view_dispatcher, StorageSettingsViewDialogEx);
 
@@ -47,7 +48,13 @@ void storage_settings_scene_formatting_on_enter(void* context) {
     dialog_ex_set_result_callback(dialog_ex, storage_settings_scene_formatting_dialog_callback);
 
     if(error != FSE_OK) {
-        dialog_ex_set_header(dialog_ex, "Cannot Format SD Card", 64, 10, AlignCenter, AlignCenter);
+        dialog_ex_set_header(
+            dialog_ex,
+            STORAGE_SETTINGS_UI_TEXT("Cannot Format SD Card", "无法格式化 SD 卡"),
+            64,
+            10,
+            AlignCenter,
+            AlignCenter);
         dialog_ex_set_icon(dialog_ex, 0, 0, NULL);
         dialog_ex_set_text(
             dialog_ex, storage_error_get_desc(error), 64, 32, AlignCenter, AlignCenter);
@@ -57,7 +64,8 @@ void storage_settings_scene_formatting_on_enter(void* context) {
             power_reboot(power, PowerBootModeNormal);
         } else {
             dialog_ex_set_icon(dialog_ex, 48, 6, &I_DolphinDone_80x58);
-            dialog_ex_set_header(dialog_ex, "Formatted", 5, 10, AlignLeft, AlignTop);
+            dialog_ex_set_header(
+                dialog_ex, STORAGE_SETTINGS_UI_TEXT("Formatted", "已格式化"), 5, 10, AlignLeft, AlignTop);
             NotificationApp* notification = furi_record_open(RECORD_NOTIFICATION);
             notification_message(notification, &sequence_single_vibro);
             notification_message(notification, &sequence_set_green_255);
@@ -65,7 +73,7 @@ void storage_settings_scene_formatting_on_enter(void* context) {
             furi_record_close(RECORD_NOTIFICATION);
         }
     }
-    dialog_ex_set_left_button_text(dialog_ex, "Finish");
+    dialog_ex_set_left_button_text(dialog_ex, STORAGE_SETTINGS_UI_TEXT("Finish", "完成"));
 }
 
 bool storage_settings_scene_formatting_on_event(void* context, SceneManagerEvent event) {

--- a/applications/settings/storage_settings/scenes/storage_settings_scene_internal_info.c
+++ b/applications/settings/storage_settings/scenes/storage_settings_scene_internal_info.c
@@ -22,13 +22,20 @@ void storage_settings_scene_internal_info_on_enter(void* context) {
 
     if(error != FSE_OK) {
         dialog_ex_set_header(
-            dialog_ex, "Internal Storage Error", 64, 10, AlignCenter, AlignCenter);
+            dialog_ex,
+            STORAGE_SETTINGS_UI_TEXT("Internal Storage Error", "内部存储错误"),
+            64,
+            10,
+            AlignCenter,
+            AlignCenter);
         dialog_ex_set_text(
             dialog_ex, storage_error_get_desc(error), 64, 32, AlignCenter, AlignCenter);
     } else {
         furi_string_printf(
             app->text_string,
-            "Name: %s\nType: Virtual (/.int on SD)\nTotal: %lu KiB\nFree: %lu KiB\n",
+            STORAGE_SETTINGS_UI_TEXT(
+                "Name: %s\nType: Virtual (/.int on SD)\nTotal: %lu KiB\nFree: %lu KiB\n",
+                "名称: %s\n类型: 虚拟 (SD 上 /.int)\n总计: %lu KiB\n可用: %lu KiB\n"),
             furi_hal_version_get_name_ptr() ? furi_hal_version_get_name_ptr() : "Unknown",
             (uint32_t)(total_space / 1024),
             (uint32_t)(free_space / 1024));
@@ -36,10 +43,15 @@ void storage_settings_scene_internal_info_on_enter(void* context) {
         uint32_t free_flash =
             furi_hal_flash_get_free_end_address() - furi_hal_flash_get_free_start_address();
         if(free_flash < 1024) {
-            furi_string_cat_printf(app->text_string, "Flash: %lu B free", free_flash);
+            furi_string_cat_printf(
+                app->text_string,
+                STORAGE_SETTINGS_UI_TEXT("Flash: %lu B free", "Flash: 可用 %lu B"),
+                free_flash);
         } else {
             furi_string_cat_printf(
-                app->text_string, "Flash: %.2f KiB free", (double)free_flash / 1024);
+                app->text_string,
+                STORAGE_SETTINGS_UI_TEXT("Flash: %.2f KiB free", "Flash: 可用 %.2f KiB"),
+                (double)free_flash / 1024);
         }
 
         dialog_ex_set_text(

--- a/applications/settings/storage_settings/scenes/storage_settings_scene_sd_info.c
+++ b/applications/settings/storage_settings/scenes/storage_settings_scene_sd_info.c
@@ -20,35 +20,61 @@ void storage_settings_scene_sd_info_on_enter(void* context) {
 
     if(sd_status != FSE_OK) {
         dialog_ex_set_icon(dialog_ex, 83, 22, &I_WarningDolphinFlip_45x42);
-        dialog_ex_set_header(dialog_ex, "SD Card Not Mounted", 64, 3, AlignCenter, AlignTop);
+        dialog_ex_set_header(
+            dialog_ex,
+            STORAGE_SETTINGS_UI_TEXT("SD Card Not Mounted", "SD 卡未挂载"),
+            64,
+            3,
+            AlignCenter,
+            AlignTop);
         dialog_ex_set_text(
-            dialog_ex, "Try to reinsert\nor format SD\ncard.", 3, 19, AlignLeft, AlignTop);
-        dialog_ex_set_center_button_text(dialog_ex, "Ok");
+            dialog_ex,
+            STORAGE_SETTINGS_UI_TEXT(
+                "Try to reinsert\nor format SD\ncard.", "请重新插入\n或格式化\nSD 卡。"),
+            3,
+            19,
+            AlignLeft,
+            AlignTop);
+        dialog_ex_set_center_button_text(dialog_ex, STORAGE_SETTINGS_UI_TEXT("Ok", "确定"));
     } else {
         furi_string_printf(
             app->text_string,
-            "Label: %s\nType: %s\n",
+            STORAGE_SETTINGS_UI_TEXT("Label: %s\nType: %s\n", "标签: %s\n类型: %s\n"),
             sd_info.label,
             sd_api_get_fs_type_text(sd_info.fs_type));
 
         if(sd_info.kb_total < 1024) {
-            furi_string_cat_printf(app->text_string, "Total: %lu KiB\n", sd_info.kb_total);
+            furi_string_cat_printf(
+                app->text_string,
+                STORAGE_SETTINGS_UI_TEXT("Total: %lu KiB\n", "总计: %lu KiB\n"),
+                sd_info.kb_total);
         } else if(sd_info.kb_total < 1024 * 1024) {
             furi_string_cat_printf(
-                app->text_string, "Total: %.2f MiB\n", (double)sd_info.kb_total / 1024);
+                app->text_string,
+                STORAGE_SETTINGS_UI_TEXT("Total: %.2f MiB\n", "总计: %.2f MiB\n"),
+                (double)sd_info.kb_total / 1024);
         } else {
             furi_string_cat_printf(
-                app->text_string, "Total: %.2f GiB\n", (double)sd_info.kb_total / (1024 * 1024));
+                app->text_string,
+                STORAGE_SETTINGS_UI_TEXT("Total: %.2f GiB\n", "总计: %.2f GiB\n"),
+                (double)sd_info.kb_total / (1024 * 1024));
         }
 
         if(sd_info.kb_free < 1024) {
-            furi_string_cat_printf(app->text_string, "Free: %lu KiB", sd_info.kb_free);
+            furi_string_cat_printf(
+                app->text_string,
+                STORAGE_SETTINGS_UI_TEXT("Free: %lu KiB", "可用: %lu KiB"),
+                sd_info.kb_free);
         } else if(sd_info.kb_free < 1024 * 1024) {
             furi_string_cat_printf(
-                app->text_string, "Free: %.2f MiB", (double)sd_info.kb_free / 1024);
+                app->text_string,
+                STORAGE_SETTINGS_UI_TEXT("Free: %.2f MiB", "可用: %.2f MiB"),
+                (double)sd_info.kb_free / 1024);
         } else {
             furi_string_cat_printf(
-                app->text_string, "Free: %.2f GiB", (double)sd_info.kb_free / (1024 * 1024));
+                app->text_string,
+                STORAGE_SETTINGS_UI_TEXT("Free: %.2f GiB", "可用: %.2f GiB"),
+                (double)sd_info.kb_free / (1024 * 1024));
         }
         furi_string_cat_printf(
             app->text_string, "  (%.2f%%)\n", (double)sd_info.kb_free * 100 / sd_info.kb_total);

--- a/applications/settings/storage_settings/scenes/storage_settings_scene_unmounted.c
+++ b/applications/settings/storage_settings/scenes/storage_settings_scene_unmounted.c
@@ -15,12 +15,30 @@ void storage_settings_scene_unmounted_on_enter(void* context) {
     if(sd_status == FSE_NOT_READY) {
         FS_Error error = storage_sd_mount(app->fs_api);
         if(error == FSE_OK) {
-            dialog_ex_set_header(dialog_ex, "SD Card Mounted", 64, 3, AlignCenter, AlignTop);
+            dialog_ex_set_header(
+                dialog_ex,
+                STORAGE_SETTINGS_UI_TEXT("SD Card Mounted", "SD 卡已挂载"),
+                64,
+                3,
+                AlignCenter,
+                AlignTop);
             dialog_ex_set_text(
-                dialog_ex, "Flipper can use\nSD card now.", 3, 22, AlignLeft, AlignTop);
+                dialog_ex,
+                STORAGE_SETTINGS_UI_TEXT(
+                    "Flipper can use\nSD card now.", "Flipper 现在\n可以使用 SD 卡。"),
+                3,
+                22,
+                AlignLeft,
+                AlignTop);
             notification_message(app->notification, &sequence_blink_green_100);
         } else {
-            dialog_ex_set_header(dialog_ex, "Cannot Mount SD Card", 64, 3, AlignCenter, AlignTop);
+            dialog_ex_set_header(
+                dialog_ex,
+                STORAGE_SETTINGS_UI_TEXT("Cannot Mount SD Card", "无法挂载 SD 卡"),
+                64,
+                3,
+                AlignCenter,
+                AlignTop);
             dialog_ex_set_text(
                 dialog_ex, storage_error_get_desc(error), 3, 22, AlignLeft, AlignTop);
             notification_message(app->notification, &sequence_blink_red_100);
@@ -28,20 +46,37 @@ void storage_settings_scene_unmounted_on_enter(void* context) {
     } else {
         FS_Error error = storage_sd_unmount(app->fs_api);
         if(error == FSE_OK) {
-            dialog_ex_set_header(dialog_ex, "SD Card Unmounted", 64, 3, AlignCenter, AlignTop);
+            dialog_ex_set_header(
+                dialog_ex,
+                STORAGE_SETTINGS_UI_TEXT("SD Card Unmounted", "SD 卡已卸载"),
+                64,
+                3,
+                AlignCenter,
+                AlignTop);
             dialog_ex_set_text(
-                dialog_ex, "You can remove\nSD card now.", 3, 22, AlignLeft, AlignTop);
+                dialog_ex,
+                STORAGE_SETTINGS_UI_TEXT(
+                    "You can remove\nSD card now.", "现在可以\n取出 SD 卡。"),
+                3,
+                22,
+                AlignLeft,
+                AlignTop);
             notification_message(app->notification, &sequence_blink_green_100);
         } else {
             dialog_ex_set_header(
-                dialog_ex, "Cannot Unmount SD Card", 64, 3, AlignCenter, AlignTop);
+                dialog_ex,
+                STORAGE_SETTINGS_UI_TEXT("Cannot Unmount SD Card", "无法卸载 SD 卡"),
+                64,
+                3,
+                AlignCenter,
+                AlignTop);
             dialog_ex_set_text(
                 dialog_ex, storage_error_get_desc(error), 3, 22, AlignLeft, AlignTop);
             notification_message(app->notification, &sequence_blink_red_100);
         }
     }
 
-    dialog_ex_set_center_button_text(dialog_ex, "OK");
+    dialog_ex_set_center_button_text(dialog_ex, STORAGE_SETTINGS_UI_TEXT("OK", "确定"));
     dialog_ex_set_icon(dialog_ex, 83, 22, &I_WarningDolphinFlip_45x42);
 
     dialog_ex_set_context(dialog_ex, app);


### PR DESCRIPTION
## Summary

Localize core Momentum UI strings for Simplified Chinese builds.

This covers frequently visible firmware UI areas that were still shown in English even when the Chinese runtime and font resources were present.

## Covered areas

- NFC start menu language switch hookup
- Storage settings screens
- Loader and storage loader menu prompts
- Power off / low battery dialog text
- Common GUI menu prompts
- Byte input text
- Bluetooth pairing service dialog text

## Notes

- Existing protocol and product identifiers are preserved where appropriate.
- The NFC change makes `NFC_UI_TEXT(en, zh)` respect `MOMENTUM_UI_LANG_ZH_CN` instead of always returning English.
- External app localization is submitted separately in `kalicyh/Momentum-Apps` because `applications/external` is a submodule.

Related external app PR: https://github.com/kalicyh/Momentum-Apps/pull/2

## Validation

Local validation was performed while building the Chinese Momentum package:

- Built touched FAP/core targets in batches during localization work.
- Built full updater packages with `MOMENTUM_UI_LANG=zh_CN ./fbt updater_package COMPACT=1 DEBUG=0`.
- Verified the latest release bundle contains Chinese runtime/font resources with the local `verify-release-bundle --expect-zh` gate.
- Hot-tested selected app updates on a Flipper Zero device.
